### PR TITLE
feat: option to create helm release in terraform

### DIFF
--- a/reducto-helm-release.tf
+++ b/reducto-helm-release.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "helm_release" "reducto" {
-  count = var.create_reducto_helm_release ? 1 : 0
+  count            = var.create_reducto_helm_release ? 1 : 0
   namespace        = "reducto"
   name             = "reducto"
   create_namespace = true

--- a/reducto-helm-release.tf
+++ b/reducto-helm-release.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "helm_release" "reducto" {
+  count = var.create_reducto_helm_release ? 1 : 0
   namespace        = "reducto"
   name             = "reducto"
   create_namespace = true

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,12 @@ variable "reducto_helm_repo_password" {
   description = "Password for Helm Registry for Reducto Helm Chart"
 }
 
+variable "create_reducto_helm_release" {
+  description = "Create Reducto Helm Release, useful if you manage k8s resources outside of terraform"
+  type        = bool
+  default     = true
+}
+
 variable "reducto_helm_chart_version" {
   description = "Reducto Helm Chart version"
   default     = "1.10.0"


### PR DESCRIPTION
When k8s resources are managed outside of Terraform - `var.create_reducto_helm_release` can be used to disable creation of Helm Release from Terraform. 