### PR TITLE
RED-1124: Disable TLS 1.0 and TLS 1.1, only allow TLS 1.2+

### DIFF
--- a/nginx-ingress-controller.tf
+++ b/nginx-ingress-controller.tf
@@ -1,3 +1,21 @@
+# ConfigMap for NGINX Ingress Controller configuration
+# Security: Disable TLS 1.0 and TLS 1.1, only allow TLS 1.2 and TLS 1.3
+resource "kubectl_manifest" "nginx-ingress-config" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: nginx-internal-nginx-ingress-controller
+      namespace: app-routing-system
+    data:
+      ssl-protocols: "TLSv1.2 TLSv1.3"
+    YAML
+
+  depends_on = [
+    azurerm_kubernetes_cluster.main,
+  ]
+}
+
 resource "kubectl_manifest" "nginx-ingress-controller" {
   yaml_body = <<-YAML
     apiVersion: approuting.kubernetes.azure.com/v1alpha1
@@ -16,7 +34,8 @@ resource "kubectl_manifest" "nginx-ingress-controller" {
     azurerm_kubernetes_cluster.main,
     azurerm_subnet.aks,
     azurerm_role_assignment.aks_network_contributor,
-    azurerm_role_assignment.web_app_routing_dns_contributor
+    azurerm_role_assignment.web_app_routing_dns_contributor,
+    kubectl_manifest.nginx-ingress-config
   ]
 }
 


### PR DESCRIPTION
## Summary

Addresses pentest finding RED-1124 by configuring the NGINX Ingress Controller to only accept TLS 1.2 and TLS 1.3 connections, disabling the deprecated TLS 1.0 and TLS 1.1 protocols.

The change adds a ConfigMap in the `app-routing-system` namespace with `ssl-protocols: "TLSv1.2 TLSv1.3"` that should be picked up by the Azure App Routing NGINX Ingress Controller.

## Review & Testing Checklist for Human

- [ ] **Verify ConfigMap naming convention**: The ConfigMap is named `nginx-internal-nginx-ingress-controller` - confirm this matches Azure App Routing's expected naming pattern for the controller to pick up the configuration automatically. Azure App Routing may use a different convention than standard NGINX Ingress Controller.
- [ ] **Test in a real AKS environment**: Deploy to a test cluster and verify TLS 1.0/1.1 connections are rejected using a tool like `openssl s_client -connect <host>:443 -tls1` or `nmap --script ssl-enum-ciphers`.
- [ ] **Verify the ConfigMap is applied**: After deployment, check that the NGINX controller pods have loaded the new ssl-protocols setting by inspecting the nginx.conf or controller logs.

### Notes

This is part of a set of 3 PRs addressing the same pentest finding across AWS, Azure, and GCP on-prem infrastructure repos.

Link to Devin run: https://app.devin.ai/sessions/48e4a8ecef0e467cba67a65d5aa10113
Requested by: Arth Bohra (@arthbohra)